### PR TITLE
export types explictly, handle empty query params explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
   },
   "homepage": "https://github.com/coinbase-samples/core-ts#readme",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.18.0",
-    "@typescript-eslint/parser": "^8.18.0",
-    "eslint": "^9.17.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-prettier": "^5.2.1",
-    "prettier": "^3.4.2",
-    "typescript": "^5.7.2"
+    "@typescript-eslint/eslint-plugin": "^8.31.1",
+    "@typescript-eslint/parser": "^8.31.1",
+    "eslint": "^9.25.1",
+    "eslint-config-prettier": "^10.1.2",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "^3.5.3",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
-    "axios": "^1.7.9",
+    "axios": "^1.9.0",
     "axios-retry": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@coinbase-sample/core-ts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Coinbase TS Core used by other libraries and examples",
   "main": "dist/index.js",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",

--- a/src/http/coinbaseHttpRequest.ts
+++ b/src/http/coinbaseHttpRequest.ts
@@ -49,7 +49,7 @@ export class CoinbaseHttpRequest {
     this.url = requestPath;
     this.callOptions = callOptions;
     this.data = bodyParams;
-    this.params = new URLSearchParams(queryParams);
+    this.params = this.sanitizeParams(new URLSearchParams(queryParams));
 
     const headers: AxiosHeaders = this.addAuthHeader();
     this.requestOptions = {
@@ -104,8 +104,22 @@ export class CoinbaseHttpRequest {
       return '';
     }
 
-    const params = new URLSearchParams(queryParams);
+    const params = this.sanitizeParams(new URLSearchParams(queryParams));
 
     return `?${params.toString()}`;
+  }
+
+  sanitizeParams(params: URLSearchParams) {
+    const emptyParams: string[] = [];
+    params.forEach((value, key) => {
+      if (value == '') {
+        emptyParams.push(key);
+      }
+    });
+
+    emptyParams.forEach((key) => {
+      params.delete(key);
+    });
+    return params;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { CoinbaseClient } from './client';
+export { CoinbaseClient, GenericClient } from './client';
 export { CoinbaseCredentials } from './credentials';
 export { CoinbaseError, CoinbaseClientException } from './error';
 export { CoinbaseHttpClient } from './http/httpClient';
@@ -23,5 +23,11 @@ export {
   CoinbaseResponse,
   HttpClient,
   Method,
+  TransformRequestFn,
+  TransformResponseFn,
+  CoinbaseHttpClientRetryOptions,
 } from './http/options';
-export { JsonUtility } from './serialization/jsonUtility';
+export {
+  JsonUtility,
+  JsonSerializerOptions,
+} from './serialization/jsonUtility';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,8 +28,10 @@
     "module": "commonjs" /* Specify what module code is generated. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "baseUrl": "." /* Specify the base directory to resolve non-relative module names. */,
+    "paths": {
+      "@coinbase-sample/core-ts": ["dist/*"]
+    } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
@@ -69,7 +71,7 @@
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    "declarationDir": "./dist/types" /* Specify the output directory for generated declaration files. */,
 
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */


### PR DESCRIPTION
move types to their own folder in dist
explicitly handle query params being dropped if undefined or empty (edge case between URLSearchParams and Axios's params) 